### PR TITLE
Fix crit chances for normal attack

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -3669,7 +3669,7 @@ class Adventure(BaseCog):
             except Exception:
                 log.exception("Error with the new character sheet")
                 continue
-            crit_mod = max(c.dex, c.luck) // 10
+            crit_mod = max(c.dex, c.luck)
             mod = 0
             if crit_mod != 0:
                 mod = round(crit_mod / 10)


### PR DESCRIPTION
The critical modifier `crit_mod` was being divided by 10 twice for normal attacks but only once for magic and talk. This would make it require at least 100 luck or dexterity for it to affect critical chance. 
Empirical evidence seems to support this, as normal attacks frequently fumble even with high luck, but magic attacks of most players seem never to.